### PR TITLE
Add Support for Payment Creation Idempotency

### DIFF
--- a/sdk/src/main/java/com/moyasar/android/sdk/creditcard/data/models/request/PaymentRequest.kt
+++ b/sdk/src/main/java/com/moyasar/android/sdk/creditcard/data/models/request/PaymentRequest.kt
@@ -14,6 +14,7 @@ data class PaymentRequest(
     val metadata: Map<String, Any?> = HashMap(),
     val manual: Boolean = false,
     val saveCard: Boolean = false,
+    @SerializedName("given_id") val givenID: String? = null,
     val allowedNetworks: List<CreditCardNetwork> = listOf(
         CreditCardNetwork.Visa,
         CreditCardNetwork.Mastercard,

--- a/sdkdriver/src/main/java/com/moyasar/android/sdkdriver/CheckoutViewModel.kt
+++ b/sdkdriver/src/main/java/com/moyasar/android/sdkdriver/CheckoutViewModel.kt
@@ -15,6 +15,7 @@ import com.moyasar.android.sdk.creditcard.presentation.view.fragments.PaymentFra
 import com.moyasar.android.sdkdriver.customui.creditcard.CustomUIPaymentFragment
 import com.moyasar.android.sdkdriver.customui.stcpay.EnterMobileNumberCustomUIFragment
 import kotlinx.parcelize.Parcelize
+import java.util.UUID
 
 class CheckoutViewModel : ViewModel() {
     val status = MutableLiveData<Status>().default(Status.Idle)
@@ -23,6 +24,7 @@ class CheckoutViewModel : ViewModel() {
         apiKey = "pk_test_vcFUHJDBwiyRu4Bd3hFuPpTnRPY4gp2ssYdNJMY3",
         amount = 100000,
         currency = "SAR",
+        givenID = UUID.randomUUID().toString(), // generate from your side uuid (v4 is recommended) to apply Idempotency or keep it null
         description = "Sample Android SDK Payment",
         metadata = mapOf(
             "order_id" to "order_123"


### PR DESCRIPTION
This PR adds support for idempotent payment creation via Moyasar by including a given_id UUID (v4 recommended) in the payment request.