### PR TITLE
Fix update header issue

### DIFF
--- a/sdk/src/main/java/com/moyasar/android/sdk/creditcard/presentation/di/MoyasarAppContainer.kt
+++ b/sdk/src/main/java/com/moyasar/android/sdk/creditcard/presentation/di/MoyasarAppContainer.kt
@@ -19,43 +19,29 @@ object MoyasarAppContainer {
   internal lateinit var paymentRequest: PaymentRequest
   private lateinit var callback: (PaymentResult) -> Unit
 
-  private val paymentService: PaymentService by lazy {
-    PaymentService(
-      paymentRequest.apiKey,
-      paymentRequest.baseUrl
-    )
-  }
-
-  private val stcPayPaymentService: STCPayPaymentService by lazy {
-    STCPayPaymentService()
-  }
-
-  private val createPaymentUseCase by lazy {
-    CreatePaymentUseCase(paymentService)
-  }
-
-  private val validateSTCPayOTPUseCase by lazy {
-    ValidateSTCPayOTPUseCase(stcPayPaymentService)
-  }
-
-  private val createTokenUseCase by lazy {
-    CreateTokenUseCase(paymentService)
-  }
-
-val allowedNetworks
-  get() = paymentRequest.allowedNetworks
+  val allowedNetworks
+    get() = paymentRequest.allowedNetworks
 
   private var _viewModel : PaymentSheetViewModel? = null
 
-   val viewModel: PaymentSheetViewModel
+  val viewModel: PaymentSheetViewModel
     get() {
       return synchronized(this) {
         if (_viewModel == null) {
+          val paymentService = PaymentService(
+            paymentRequest.apiKey,
+            paymentRequest.baseUrl
+          )
+          val stcPayPaymentService = STCPayPaymentService()
+          val createPaymentUseCase = CreatePaymentUseCase(paymentService)
+          val validateSTCPayOTPUseCase  = ValidateSTCPayOTPUseCase(stcPayPaymentService)
+          val createTokenUseCase = CreateTokenUseCase(paymentService)
+
           _viewModel = PaymentSheetViewModel(
             application = application,
             paymentRequest = paymentRequest,
             callback = callback,
-            createPaymentUseCase = createPaymentUseCase,
+            createPaymentUseCase =createPaymentUseCase,
             createTokenUseCase = createTokenUseCase,
             validateSTCPayOTPUseCase = validateSTCPayOTPUseCase
           )


### PR DESCRIPTION
Fix update API key in header issue

## Description
- When a user adds a payment card to a Bahrain-based account, it works as expected. However, if the user then switches to a Saudi-based account within the same session and tries to add another card, the new card is still being linked to the Bahrain account.

## Fix 
we applied some logic to make API key updated in header