### PR TITLE
Add `apply_coupon` to PaymentConfig

### DIFF
--- a/sdk/src/main/java/com/moyasar/android/sdk/creditcard/data/models/request/PaymentRequest.kt
+++ b/sdk/src/main/java/com/moyasar/android/sdk/creditcard/data/models/request/PaymentRequest.kt
@@ -25,6 +25,7 @@ data class PaymentRequest(
     val createSaveOnlyToken: Boolean = false,
     val buttonType: MoyasarButtonType = MoyasarButtonType.PAY,
     val source: PaymentSource? = null,
+    @SerializedName("apply_coupon") val applyCoupon: Boolean? = true,
 
     ) {
     fun validate(): Array<String> {

--- a/sdkdriver/src/main/java/com/moyasar/android/sdkdriver/CheckoutViewModel.kt
+++ b/sdkdriver/src/main/java/com/moyasar/android/sdkdriver/CheckoutViewModel.kt
@@ -33,7 +33,8 @@ class CheckoutViewModel : ViewModel() {
         baseUrl = "https://api.moyasar.com",
         buttonType = MoyasarButtonType.PAY,
         allowedNetworks = listOf(CreditCardNetwork.Mastercard, CreditCardNetwork.Visa, CreditCardNetwork.Amex),
-        createSaveOnlyToken = false
+        createSaveOnlyToken = false,
+        applyCoupon = true
     )
 
     // For demo purposes only


### PR DESCRIPTION
 - The create payment API accepts a flag named apply_coupon. It is an optional flag with a default value of true. It controls whether an applicable coupon (based on the BIN) should be applied or not: https://docs.moyasar.com/api/payments/01-create-payment 

A real-world use case is when the merchant wants to run a promo for first-time customers only. The merchant can set this flag to false in subsequent purchases of the same customer.