### PR TITLE
fix: samsung pay internal failure issue

### DIFF
--- a/sdk/src/main/java/com/moyasar/android/sdk/samsungpay/presentation/SamsungPayManager.kt
+++ b/sdk/src/main/java/com/moyasar/android/sdk/samsungpay/presentation/SamsungPayManager.kt
@@ -224,10 +224,6 @@ object SamsungPayManager {
                 }
 
                 override fun onFailure(errorCode: Int, errorData: Bundle?) {
-                    if (errorCode == PaymentManager.ERROR_USER_CANCELED) {
-                        MoyasarLogger.log("MoyasarSDK", "Samsung Pay canceled by user")
-                        return
-                    }
                     handleOnFail(errorData ?: Bundle(), samsungPay, context, errorCode)
                     authorizePayment(null, null)
                 }


### PR DESCRIPTION
- Fix samsung pay internal failure issue that cause blocking flow after cancel